### PR TITLE
Add option to cache XML sitemap by a http cache (ie. varnish or nginx)

### DIFF
--- a/administrator/components/com_schuweb_sitemap/language/en-GB/en-GB.com_schuweb_sitemap.ini
+++ b/administrator/components/com_schuweb_sitemap/language/en-GB/en-GB.com_schuweb_sitemap.ini
@@ -83,6 +83,8 @@ SCHUWEB_SITEMAP_ATTRIBS_NEWS_POSTS_KEYWORDS_LABEL="Posts keywords"
 SCHUWEB_SITEMAP_ATTRIBS_NEWS_POSTS_KEYWORDS_DESC="Comma separated list of keywords to describe your posts. Default to the post's category title."
 SCHUWEB_SITEMAP_ATTRIBS_INCLUDE_LINK_LABEL="Link to author"
 SCHUWEB_SITEMAP_ATTRIBS_INCLUDE_LINK_DESC="Include the link to Xmap's home at the bottom of the HTML site map."
+SCHUWEB_SITEMAP_ATTRIBS_CACHE_CONTROL_LABEL="Cache-Control header"
+SCHUWEB_SITEMAP_ATTRIBS_CACHE_CONTROL_DESC="Set this to control how the sitemap should be cached by a http cache."
 
 SCHUWEB_SITEMAP_FIELDSET_XML_OPTIONS="XML Options"
 SCHUWEB_SITEMAP_XML_LAST_MOD="Insert Lastmod"

--- a/administrator/components/com_schuweb_sitemap/models/forms/sitemap.xml
+++ b/administrator/components/com_schuweb_sitemap/models/forms/sitemap.xml
@@ -298,6 +298,14 @@
                 <option
                     value="1">Yes</option>
             </field>
+
+            <field
+                name="cache_control"
+                type="text"
+                default=""
+                label="SCHUWEB_SITEMAP_ATTRIBS_CACHE_CONTROL_LABEL"
+                labelclass="control-label"
+                description="SCHUWEB_SITEMAP_ATTRIBS_CACHE_CONTROL_DESC" />
         </fieldset>
 
         <fieldset name="xmlOptions" label="SCHUWEB_SITEMAP_FIELDSET_XML_OPTIONS">

--- a/components/com_schuweb_sitemap/views/xml/tmpl/default.php
+++ b/components/com_schuweb_sitemap/views/xml/tmpl/default.php
@@ -16,6 +16,10 @@ $live_site = substr_replace(JURI::root(), "", -1, 1);
 
 header('Content-type: text/xml; charset=utf-8');
 
+if ($cacheControl = $this->item->params->get('cache_control', "")) {
+    header('Cache-Control: ' . $cacheControl);
+}
+
 $jinput = JFactory::getApplication()->input;
 
 echo '<?xml version="1.0" encoding="UTF-8"?>',"\n";


### PR DESCRIPTION
This simply sets a http header.

Example value for 10 minutes: `public,max-age=600,pre-check=600,post-check=600,must-revalidate`

This is for XML only.